### PR TITLE
ci: add basic workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,31 @@
+on:
+  pull_request:
+    branches: ["master"]
+
+name: CI
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustup component add rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo clippy -- -D warnings

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches: ["master"]
+
+name: Release
+
+jobs:
+  docker:
+    name: Docker Build and Push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate tag
+        id: tag
+        run: echo "::set-output name=value::$(date '+%Y%m%d-%H%M')"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/pgbackup:${{ steps.tag.outputs.value }}

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ impl From<&DatabaseConfig> for tokio_postgres::Config {
             .port(value.port);
 
         if let Some(password) = value.password.as_deref() {
-            config.password(password.to_owned());
+            config.password(password);
         }
 
         config

--- a/src/databases.rs
+++ b/src/databases.rs
@@ -31,7 +31,7 @@ pub async fn dump(config: &DatabaseConfig, database: &str) -> Result<Vec<u8>> {
     let mut command = Command::new("pg_dump");
 
     command
-        .args(&[
+        .args([
             "-h",
             &config.host,
             "-p",


### PR DESCRIPTION
Now that we have something that may seemingly work, let's get towards deploying it. In theory it will need to be restarted for every run, but let's prove that it works and get continuous deployments to the instance going before doing much else.

This change:
* Adds some basic CI workflows for checking the code and publishing it
* Fixes some `clippy` lints
