### PR TITLE
fix: remove exclusion clause

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,10 +61,6 @@ async fn main() -> Result<()> {
     let databases = discover(&client).await?;
 
     for database in databases {
-        if database != "tasks" {
-            continue;
-        }
-
         let dump = dump(&config, &database).await?;
         let compressed = compress(&dump)?;
 


### PR DESCRIPTION
When testing locally, this allowed for only running backups for a single database. This doesn't exist in prod, so the backup process just does nothing.

This change:
* Removes the clause
