### PR TITLE
ci: publish to `tag-updater`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,3 +22,6 @@ jobs:
         with:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/pgbackup:${{ steps.tag.outputs.value }}
+      - name: Inform `tag-updater`
+        run: |
+          curl https://tags.opentracker.app/update -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.TAG_UPDATER_PASSPHRASE }}" --data '{"service": "pgbackup", "tag": "${{ steps.tag.outputs.value }}"}'


### PR DESCRIPTION
Now that `pgbackup` is a little more stable and seems to be working sensibly, let's get `tag-updater` handling new builds for it.

This change:
* Adds the additional CI step
